### PR TITLE
Approvallayout

### DIFF
--- a/sfuthesis.cls
+++ b/sfuthesis.cls
@@ -341,11 +341,12 @@
 
 \newcommand{\chair}[2]{%
     \begin{minipage}[t]{0.1\textwidth}%
-        Chair:
+        \textbf{Chair:}
     \end{minipage}%
     \begin{minipage}[t]{0.55\textwidth}%
-    	#1 \newline
-    	#2
+        \raggedright
+        #1 \newline
+        #2
     \end{minipage}%
     \vfill
 }
@@ -353,6 +354,7 @@
 \newcommand{\member}[2]{%
     \noindent%
     \begin{minipage}[b]{0.5\textwidth}%
+        \raggedright
         \textbf{#1} \newline
         #2
     \end{minipage}%
@@ -373,6 +375,7 @@
 \newcommand{\@approvallabel}[1]{%
     \noindent%
     \begin{minipage}[t]{0.35\textwidth}%
+        \raggedright
         #1
     \end{minipage}%
     \ignorespaces%
@@ -380,7 +383,7 @@
 
 \newcommand{\@approvalvalue}[1]{%
     \begin{minipage}[t]{0.65\textwidth}%
-    	\raggedright%
+        \raggedright%
         #1
     \end{minipage}%
     \medskip\par

--- a/template.tex
+++ b/template.tex
@@ -1,6 +1,6 @@
 \documentclass{sfuthesis}
 
-\title{An example of a thesis or dissertation}
+\title{An example of a thesis or dissertation that uses this fancy latex package for illustrative purposes}
 \thesistype{Dissertation}
 \author{Stuart Arthur Dent}
 \previousdegrees{%


### PR DESCRIPTION
Based on additional emails with the library people, bolding the chair label and making all approval page text ragged right to avoid weird spacing.

An additional commit changes the length of the title to show a minor issue with respect to line spacing of the title on the first page (needs to be increased somehow) that I do not currently have a fix for.