### PR TITLE
Fix referencing inside chapters and sections

### DIFF
--- a/sfuthesis.cls
+++ b/sfuthesis.cls
@@ -184,11 +184,26 @@
 %
 
 \pretocmd{\@chapter}{\begingroup\smallspacing}{}{}
-\apptocmd{\@chapter}{\endgroup}{}{}
+\apptocmd{\@chapter}{%
+    \endgroup
+    \if@mainmatter
+        \addtocounter{chapter}{-1}%
+        \refstepcounter{chapter}%
+    \fi
+}{}{}
+
 \pretocmd{\@schapter}{\begingroup\smallspacing}{}{}
 \apptocmd{\@schapter}{\endgroup}{}{}
+
 \pretocmd{\@sect}{\begingroup\smallspacing}{}{}
-\apptocmd{\@sect}{\endgroup}{}{}
+\apptocmd{\@sect}{%
+    \endgroup
+    \if@mainmatter
+        \addtocounter{section}{-1}%
+        \refstepcounter{section}%
+    \fi
+}{}{}
+
 \pretocmd{\@ssect}{\begingroup\smallspacing}{}{}
 \apptocmd{\@ssect}{\endgroup}{}{}
 


### PR DESCRIPTION
This will fix issue #21.
After reporting the bug and asking the community online, this was suggested to me, which is working correctly.
You can see the answer proposed to this bug on [latex stackexchange](https://tex.stackexchange.com/questions/375383/defining-a-label-inside-begingroup)