### PR TITLE
Fix overfull \hbox on Approval page

### DIFF
--- a/sfuthesis.cls
+++ b/sfuthesis.cls
@@ -390,7 +390,7 @@
 
 \newcommand{\@approvallabel}[1]{%
     \noindent%
-    \begin{minipage}[t]{0.35\textwidth}%
+    \begin{minipage}[t]{0.34\textwidth}%
         \raggedright
         \textbf{#1}
     \end{minipage}%


### PR DESCRIPTION
Fix warning "Overfull \hbox (2.43332pt too wide) in paragraph".
It was previously fixed for #12 by 8cb9346, but then reintroduced in b7db82d.